### PR TITLE
Forward metrics port 5052

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,5 +15,6 @@ services:
     ports:
       - '9000:9000'
       - '9000:9000/udp'
+      - '5052:5052'
 volumes:
   data: {}


### PR DESCRIPTION
Exposing metrics allows one to use a monitoring service such as eth2stats.io