### PR TITLE
bump sigp/lighthouse to v0.3.2

### DIFF
--- a/.github/workflows/auto_check.yml
+++ b/.github/workflows/auto_check.yml
@@ -1,9 +1,11 @@
 name: Bump upstream version
 
 on:
-  push:
   schedule:
     - cron: "00 */4 * * *"
+  push:
+    branches:
+      - "master"
 jobs:
   bump-upstream:
     runs-on: ubuntu-latest

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "lighthouse-medalla-beacon-chain.dnp.dappnode.eth",
   "version": "1.0.7",
-  "upstreamVersion": "v0.3.0",
+  "upstreamVersion": "v0.3.2",
   "upstreamRepo": "sigp/lighthouse",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Lighthouse Medalla ETH2.0 Beacon chain",
@@ -23,9 +23,7 @@
   "requirements": {
     "minimumDappnodeVersion": "0.2.20"
   },
-  "categories": [
-    "Blockchain"
-  ],
+  "categories": ["Blockchain"],
   "links": {
     "readme": "https://github.com/dappnode/DAppNodePackage-lighthouse-medalla-beacon-chain",
     "lighthouse": "https://github.com/sigp/lighthouse"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,19 @@
-version: '3.4'
+version: "3.4"
 services:
   lighthouse-medalla-beacon-chain.dnp.dappnode.eth:
     build:
       context: ./build
       args:
-        UPSTREAM_VERSION: v0.3.0
-    image: 'lighthouse-medalla-beacon-chain.dnp.dappnode.eth:1.0.7'
+        UPSTREAM_VERSION: v0.3.2
+    image: "lighthouse-medalla-beacon-chain.dnp.dappnode.eth:1.0.7"
     restart: always
     environment:
-      - 'HTTP_WEB3PROVIDER=http://goerli-geth.dappnode:8545'
+      - "HTTP_WEB3PROVIDER=http://goerli-geth.dappnode:8545"
       - EXTRA_OPTS
     volumes:
-      - 'data:/data'
+      - "data:/data"
     ports:
-      - '9000'
-      - '9000/udp'
+      - "9000"
+      - 9000/udp
 volumes:
   data: {}


### PR DESCRIPTION
Bumps upstream version

- [sigp/lighthouse](https://github.com/sigp/lighthouse) from v0.3.0 to [v0.3.2](https://github.com/sigp/lighthouse/releases/tag/v0.3.2)