### PR TITLE
bump sigp/lighthouse to v0.3.4

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "lighthouse-medalla-beacon-chain.dnp.dappnode.eth",
   "version": "1.0.7",
-  "upstreamVersion": "v0.3.2",
+  "upstreamVersion": "v0.3.4",
   "upstreamRepo": "sigp/lighthouse",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Lighthouse Medalla ETH2.0 Beacon chain",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ./build
       args:
-        UPSTREAM_VERSION: v0.3.2
+        UPSTREAM_VERSION: v0.3.4
     image: "lighthouse-medalla-beacon-chain.dnp.dappnode.eth:1.0.7"
     restart: always
     environment:


### PR DESCRIPTION
Bumps upstream version

- [sigp/lighthouse](https://github.com/sigp/lighthouse) from v0.3.2 to [v0.3.4](https://github.com/sigp/lighthouse/releases/tag/v0.3.4)